### PR TITLE
Add --env

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -35,7 +35,7 @@ const getConfig = options => {
     reportDir: process.env.REPORT_DIR ?
       path.resolve(process.env.REPORT_DIR) : path.resolve(process.cwd(), 'reports', 'test-e2e'),
     nightwatchConfig,
-    nightwatchEnv: process.env.NIGHTWATCH_ENV || default,
+    nightwatchEnv: process.env.NIGHTWATCH_ENV || "default",
     webpackConfig: process.env.WEBPACK_CONFIG ?
       path.resolve(process.env.WEBPACK_CONFIG) : path.resolve(process.cwd(), 'webpack.config.js'),
     port: process.env.NODE_PORT || process.env.PORT || 8080,

--- a/runner.js
+++ b/runner.js
@@ -35,10 +35,11 @@ const getConfig = options => {
     reportDir: process.env.REPORT_DIR ?
       path.resolve(process.env.REPORT_DIR) : path.resolve(process.cwd(), 'reports', 'test-e2e'),
     nightwatchConfig,
+    nightwatchEnv: process.env.NIGHTWATCH_ENV || default,
     webpackConfig: process.env.WEBPACK_CONFIG ?
       path.resolve(process.env.WEBPACK_CONFIG) : path.resolve(process.cwd(), 'webpack.config.js'),
     port: process.env.NODE_PORT || process.env.PORT || 8080,
-    tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || "",
+    tunnelIdentifier: process.env.TUNNEL_IDENTIFIER || undefined,
   }, options);
 
   console.log(`Running with config:\n${util.inspect(config, {depth: 0, colors: true})}`);
@@ -70,6 +71,7 @@ module.exports = options => {
     cp.fork(nightwatchRunner,
       [
         '--config', config.nightwatchConfig,
+        '--env', config.nightwatchEnv,
         '--output', config.reportDir
       ])
       .on('error', err2 => {


### PR DESCRIPTION
Allows for handling multiple environments in one file (nightwatch.json). Passes process.env.NIGHTWATCH_ENV into the runner as --env

PS. I also set the tunnelIdentifier to undefined in case there is no input. If you think thats a bad idea, I'll change it back.
