### PR TITLE
Add callback to child_process exec to get test results, use only on windows.

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -72,17 +72,36 @@ module.exports = options => {
       '--config', config.nightwatchConfig,
       '--env', config.nightwatchEnv,
       '--output', config.reportDir
-    ].join(' ');
+    ];
 
-    cp.exec(`${nightwatchRunner} ${args}`)
-      .on('error', err2 => {
-        console.error(err2.stack);
-        process.exit(1);
-      })
-      .on('close', code => {
-        seleniumChild.kill('SIGINT');
-        process.exit(code);
-      });
+    if (process.platform === 'win32') {
+      cp.exec(`${nightwatchRunner} ${args.join(' ')}`,
+        (error, stdout, stderr) => {
+          console.log(`${stdout}`);
+          console.log(`${stderr}`);
+          if (error !== null) {
+            console.log(`exec error: ${error}`);
+          }
+        })
+        .on('error', err2 => {
+          console.error(err2.stack);
+          process.exit(1);
+        })
+        .on('close', code => {
+          seleniumChild.kill('SIGINT');
+          process.exit(code);
+        });
+    } else {
+      cp.fork(nightwatchRunner, args)
+        .on('error', err2 => {
+          console.error(err2.stack);
+          process.exit(1);
+        })
+        .on('close', code => {
+          seleniumChild.kill('SIGINT');
+          process.exit(code);
+        });
+    }
   };
 
 


### PR DESCRIPTION
I added a callback to habe the results output to console. With exec the child process is called in a new shell and buffered. So we only get the results after the test has finished via callback. 
For large tests one would maybe have to set the maxBuffer option on exec.

I think it might therefore make sense to fall back to using fork with all other OS. 
Then you also get the results as you go and don't have to wait until the end to see them. (not on Windows obvsly)
