### PR TITLE
Add logger for selenium-standalone

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -130,5 +130,9 @@ module.exports = options => {
     selenium.start({seleniumArgs: ['-debug']}, onSeleniumStarted);
   }
 
-  selenium.install({}, onSeleniumInstalled);
+  selenium.install({
+    logger: message => console.log(message),
+    progressCb: (totalLength, progressLength) =>
+      console.log(`Downloading: ${(100 * (progressLength / totalLength)).toFixed(2)}%`)
+  }, onSeleniumInstalled);
 };

--- a/runner.js
+++ b/runner.js
@@ -130,9 +130,15 @@ module.exports = options => {
     selenium.start({seleniumArgs: ['-debug']}, onSeleniumStarted);
   }
 
+  let progress;
   selenium.install({
     logger: message => console.log(message),
-    progressCb: (totalLength, progressLength) =>
-      console.log(`Downloading: ${(100 * (progressLength / totalLength)).toFixed(2)}%`)
+    progressCb: (totalLength, progressLength) => {
+      const newProgress = (100 * (progressLength / totalLength));
+      if (!progress || (newProgress - progress > 5) || progress > 99.99) {
+        progress = newProgress;
+        console.log(`Downloading: ${progress.toFixed(2)}%`);
+      }
+    }
   }, onSeleniumInstalled);
 };

--- a/runner.js
+++ b/runner.js
@@ -135,7 +135,7 @@ module.exports = options => {
     logger: message => console.log(message),
     progressCb: (totalLength, progressLength) => {
       const newProgress = (100 * (progressLength / totalLength));
-      if (!progress || (newProgress - progress > 5) || progress > 99.99) {
+      if (!progress || (newProgress - progress > 5) || progress > 99) {
         progress = newProgress;
         console.log(`Downloading: ${progress.toFixed(2)}%`);
       }


### PR DESCRIPTION
So it is possible to see that it is not stuck

Looks better now

```
REPORT_DIR=${CIRCLE_TEST_REPORTS} LOG_DIR=${CIRCLE_ARTIFACTS} node test.js
Fallback to default nightwatch.json config
Running with config:
{ logDir: '/tmp/circle-artifacts.gJVvNpn',

  reportDir: '/tmp/circle-junit.ITbm43x',

  nightwatchConfig: '/home/ubuntu/nightwatch-autorun/nightwatch.json',

  nightwatchEnv: 'default',

  webpackConfig: '/home/ubuntu/nightwatch-autorun/test/webpack.config.js',

  port: 8080,

  tunnelIdentifier: undefined }
----------
selenium-standalone installation starting
----------

---
selenium install:
from: https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar
to: /home/ubuntu/nightwatch-autorun/node_modules/selenium-standalone/.selenium/selenium-server/2.53.1-server.jar

---
chrome install:
from: https://chromedriver.storage.googleapis.com/2.22/chromedriver_linux64.zip
to: /home/ubuntu/nightwatch-autorun/node_modules/selenium-standalone/.selenium/chromedriver/2.22-x64-chromedriver

---
firefox install:
from: https://github.com/mozilla/geckodriver/releases/download/v0.9.0/geckodriver-v0.9.0-linux64.tar.gz
to: /home/ubuntu/nightwatch-autorun/node_modules/selenium-standalone/.selenium/geckodriver/0.9.0-x64-geckodriver
Downloading: 13.50%
Downloading: 18.50%
Downloading: 23.54%
Downloading: 28.55%
Downloading: 33.60%
Downloading: 38.61%
Downloading: 43.62%
Downloading: 48.63%
Downloading: 53.64%
Downloading: 58.64%
Downloading: 63.65%
Downloading: 68.66%
Downloading: 73.67%
Downloading: 78.68%
Downloading: 83.69%
Downloading: 88.69%
Downloading: 93.70%
Downloading: 98.71%
Downloading: 99.03%
Downloading: 99.10%
Downloading: 99.16%
Downloading: 99.23%
Downloading: 99.29%
Downloading: 99.36%
Downloading: 99.42%
Downloading: 99.49%
Downloading: 99.55%
Downloading: 99.62%
Downloading: 99.69%
Downloading: 99.75%
Downloading: 99.82%
Downloading: 99.88%
Downloading: 99.95%
Downloading: 100.00%


-----
selenium-standalone installation finished
-----

[Index] Test Suite
======================

Running:  Smoketest
 ✔ Element <body> was visible after 220 milliseconds.
 ✔ Testing if element <body> contains text: "Hello, World!".

OK. 2 assertions passed. (6.607s)
```
